### PR TITLE
Add missing Attribute class

### DIFF
--- a/src/Message/Attribute.php
+++ b/src/Message/Attribute.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Trademachines\Riemann\Message;
+
+use DrSlump\Protobuf\AnnotatedMessage;
+
+/**
+ * Class Attribute
+ */
+class Attribute extends AnnotatedMessage
+{
+    /** @protobuf(tag=1, type=string, required) */
+    public $key;
+
+    /** @protobuf(tag=2, type=string, optional) */
+    public $value;
+
+    public static function create($key, $value)
+    {
+        $attribute = new Attribute();
+        $attribute->key = $key;
+        $attribute->value = $value;
+        return $attribute;
+    }
+}


### PR DESCRIPTION
Quick 'n dirty implementation of Attribute, which was being referenced from Event but missing from the tree.